### PR TITLE
Update devDependencies / Fix JSHint seting

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -3,7 +3,6 @@
   "curly": true,
   "eqeqeq": true,
   "eqnull": true,
-  "es5": true,
   "evil": true,
   "expr": true,
   "immed": true,

--- a/package.json
+++ b/package.json
@@ -35,12 +35,12 @@
   "devDependencies": {
     "grunt": "~0.4.2",
     "grunt-contrib-clean": "~0.5.0",
-    "grunt-contrib-jshint": "~0.2.0",
-    "grunt-contrib-nodeunit": "~0.1.2",
+    "grunt-contrib-jshint": "~0.8.0",
+    "grunt-contrib-nodeunit": "~0.3.0",
     "grunt-contrib-watch": "~0.5.3",
     "grunt-jsonlint": "~1.0.4",
     "jshint-stylish": "~0.1.3",
-    "load-grunt-tasks": "~0.2.0"
+    "load-grunt-tasks": "~0.3.0"
   },
   "scripts": {
     "test": "grunt test"


### PR DESCRIPTION
I updated devDependencies of this project and fixed JSHint setting. Now there is no need to set the "ES5" option explicitly. (cf. http://www.jshint.com/blog/2013-05-07/2-0-0/).
