### PR TITLE
Package: Fix bugs URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/timmywil/grunt-bowercopy.git"
   },
-  "bugs": "https://github.com/timmywil/grunt-bowercopy.git/issues",
+  "bugs": "https://github.com/timmywil/grunt-bowercopy/issues",
   "author": {
     "name": "Timmy Willison",
     "email": "timmywillisn@gmail.com",


### PR DESCRIPTION
Clicking the bugs link on npmjs.org lead to a 404 page, just what I needed when I wanted to report an actual bug.
