### PR TITLE
Implement ignore option

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -33,7 +33,8 @@ module.exports = function (grunt) {
 		bowercopy: {
 			options: {
 				clean: true,
-				report: false
+				report: false,
+				ignore: ['jquery-1.x']
 			},
 			default_options: {
 				files: {

--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ Default value: `''`
 
 `destPrefix` will be used as the prefix for destinations.
 
+#### options.ignore
+Type: `Array`  
+Default value: `[]`
+
+`ignore` can be specified for any bower dependencies that aren't copied, but need to be defined anyway.
+
 #### options.report
 Type: `Boolean`  
 Default value: `true`

--- a/bower.json
+++ b/bower.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "backbone": "1.1.0",
     "chosen": "1.0.0",
+    "jquery-1.x": "jquery#1.11.0",
     "jquery": "2.1.0",
     "jquery.panzoom": "1.8.1",
     "jquery-ui": "jquery/jquery-ui#c0ab71056b936627e8a7821f03c044aec6280a40",

--- a/tasks/bowercopy.js
+++ b/tasks/bowercopy.js
@@ -91,6 +91,9 @@ module.exports = function (grunt) {
 	 */
 	function filterRepresented(modules, files, options) {
 		return _.filter(modules, function(module) {
+			if (options.ignore.indexOf(module) !== -1) {
+				return false;
+			}
 			return !_.some(files, function(file) {
 				// Look for the module name somewhere in the source path
 				return path.join(sep, options.srcPrefix, file.src, sep)
@@ -250,6 +253,7 @@ module.exports = function (grunt) {
 			var options = this.options({
 				srcPrefix: bower.config.directory,
 				destPrefix: '',
+				ignore: [],
 				report: true,
 				runBower: true,
 				clean: false,


### PR DESCRIPTION
Fixes gh-19

Couldn't figure out how to test this without modifying the options for all targets. Also considered supporting `ignore` as a string, similar to how you can set files to a string or array of strings. Seemed unnecessarily complicated for this option.
