### PR TITLE
origin can be a callback function

### DIFF
--- a/tasks/bowercopy.js
+++ b/tasks/bowercopy.js
@@ -75,6 +75,9 @@ module.exports = function (grunt) {
 			}
 
 			file.src.forEach(function(source) {
+				if(typeof source === 'function') {
+					source = source();
+				}
 				converted.push({
 					src: source,
 					dest: dest


### PR DESCRIPTION
I came across a case where the name of the file to copy included the version, which can be found in the module's bower.json file. It is easily done if the source is a callback that returns the source file. For example, for easel.js, here is what I use instead of a string:

```
vendor: {
    options: {
        destPrefix: 'js/vendor',
    },
     files: {
        'easel.js' : function(){
            var easelCnf = grunt.file.readJSON('bower_components/EaselJS/bower.json');
            return 'EaselJS/lib/easeljs-' + easelCnf.version + '.min.js';
        }
    }
},
```

The callback can return only a string, not an array. It could be modified to return a list of files, but I kept it as simple as possible.
