### PR TITLE
Add .bowerrc cwd value to get bower.json path

### DIFF
--- a/tasks/bowercopy.js
+++ b/tasks/bowercopy.js
@@ -21,7 +21,14 @@ module.exports = function (grunt) {
 		bower = require('bower'),
 		glob = require('glob'),
 		sep = path.sep;
-
+	
+	// Get path to bower config file
+	var bowerrc = grunt.file.readJSON('.bowerrc');
+	var bowerConfigPath = 'bower.json';
+	if(bowerrc.cwd !== undefined) {
+		bowerConfigPath = bowerrc.cwd + '/' + bowerConfigPath;
+	}
+	
 	// Get all modules
 	var bowerConfig = grunt.file.readJSON('bower.json');
 	var allModules = Object.keys(

--- a/tasks/bowercopy.js
+++ b/tasks/bowercopy.js
@@ -30,7 +30,7 @@ module.exports = function (grunt) {
 	}
 	
 	// Get all modules
-	var bowerConfig = grunt.file.readJSON('bower.json');
+	var bowerConfig = grunt.file.readJSON(bowerConfigPath);
 	var allModules = Object.keys(
 		_.extend({}, bowerConfig.dependencies, bowerConfig.devDependencies)
 	);


### PR DESCRIPTION
This fixes bowercopy not using the cwd in .bowerrc to locate bower.json, and the components folder not being detected using .bowerrc can be determined using srcPrefix and destPrefix after reading the .bowerrc json directory value.