### PR TITLE
Fixed building srcPrefix

### DIFF
--- a/tasks/bowercopy.js
+++ b/tasks/bowercopy.js
@@ -287,7 +287,7 @@ module.exports = function (grunt) {
 
 			// Options
 			var options = this.options({
-				srcPrefix: bower.config.directory,
+				srcPrefix: path.join(bower.config.cwd, bower.config.directory),
 				destPrefix: '',
 				ignore: [],
 				report: true,

--- a/tasks/bowercopy.js
+++ b/tasks/bowercopy.js
@@ -284,10 +284,18 @@ module.exports = function (grunt) {
 		function bowercopy() {
 			var self = this;
 			var files = this.files;
+			
+			var srcPrefix = '';
+			if (bower.config.directory && grunt.file.isPathAbsolute(bower.config.directory)) {
+				srcPrefix = bower.config.directory;
+			}
+			else {
+				srcPrefix = path.join(bower.config.cwd, bower.config.directory);
+			}
 
 			// Options
 			var options = this.options({
-				srcPrefix: path.join(bower.config.cwd, bower.config.directory),
+				srcPrefix: srcPrefix,
 				destPrefix: '',
 				ignore: [],
 				report: true,


### PR DESCRIPTION
According to bower documentation http://bower.io/docs/config/#cwd srcPrefix should be build out of `cwd` and `directory` parameters