### PR TITLE
Fix reading .bowerrc when it doesn't exist

### DIFF
--- a/tasks/bowercopy.js
+++ b/tasks/bowercopy.js
@@ -23,10 +23,13 @@ module.exports = function (grunt) {
 		sep = path.sep;
 
 	// Get path to bower config file
-	var bowerrc = grunt.file.readJSON('.bowerrc');
 	var bowerConfigPath = 'bower.json';
-	if (bowerrc.cwd) {
-		bowerConfigPath = path.join(bowerrc.cwd, bowerConfigPath);
+	var bowerrcPath = '.bowerrc';
+	if (grunt.file.exists(bowerrcPath)){
+		var bowerrc = grunt.file.readJSON(bowerrcPath);
+		if (bowerrc.cwd) {
+			bowerConfigPath = path.join(bowerrc.cwd, bowerConfigPath);
+		}
 	}
 
 	// Get all modules


### PR DESCRIPTION
If no .bowerrc file exists in the root-directory then bowercopy fails with the following error:
>Loading "bowercopy.js" tasks...ERROR
>Error: Unable to read ".bowerrc" file (Error code: ENOENT).

Checking if the file exists before reading it should fix the task from crashing. See #39