### PR TITLE
Fix :main pragma on Windows

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -103,6 +103,21 @@ module.exports = function (grunt) {
 			main: {
 				src: 'jquery.minlight:main',
 				dest: 'tmp/js/plugins/'
+			},
+			// Main pragma with complicated destPrefix
+			main_with_complex_dest_prefix: {
+				options: {
+					destPrefix: 'tmp/js/main_with_complex_dest_prefix'
+				},
+				src: 'angular:main',
+				dest: 'angular'
+			},
+			// Main pragma with no dest (so bowercopy uses the src as the dest)
+			main_with_no_dest: {
+				options: {
+					destPrefix: 'tmp/js/libs'
+				},
+				src: 'angular:main'
 			}
 		},
 

--- a/bower.json
+++ b/bower.json
@@ -29,6 +29,7 @@
     "jquery.minlight": "0.6.0",
     "jquery.panzoom": "1.8.1",
     "jquery-ui": "jquery/jquery-ui#c0ab71056b936627e8a7821f03c044aec6280a40",
-    "lodash": "2.4.1"
+    "lodash": "2.4.1",
+    "angular": "1.4.3"
   }
 }

--- a/tasks/bowercopy.js
+++ b/tasks/bowercopy.js
@@ -215,6 +215,13 @@ module.exports = function (grunt) {
 			// Copy main files if :main is specified
 			var main = rmain.exec(src);
 			if (main) {
+				//Trim :main from dest strings
+				//(required if the user did not also provide an explicit dest)
+				var temp = rmain.exec(dest);
+				if (temp) {
+					dest = temp[1];
+				}
+
 				copied = copy(getMain(main[1], options, dest), options) || copied;
 				return;
 			}

--- a/tasks/bowercopy.js
+++ b/tasks/bowercopy.js
@@ -42,7 +42,7 @@ module.exports = function (grunt) {
 
 	// Regex
 	var rperiod = /\./;
-	var rmain = /^([^:]+):main$/;
+	var rmain = /^(.+):main$/;
 
 	/**
 	 * Retrieve the number of targets from the grunt config

--- a/tasks/bowercopy.js
+++ b/tasks/bowercopy.js
@@ -196,10 +196,11 @@ module.exports = function (grunt) {
 	function copy(files, options) {
 		var copied = false;
 		files.forEach(function(file) {
-			var src = file.src;
-			// Use source for destination if no destionation is available
+			// Normalize input
+			var src = path.normalize(file.src);
+			// Use source for destination if no destination is available
 			// This is done here so globbing can use the original dest
-			var dest = file.dest || src;
+			var dest = path.normalize(file.dest || src);
 
 			// Add source prefix if not already added
 			if (src.indexOf(options.srcPrefix) !== 0) {
@@ -260,6 +261,10 @@ module.exports = function (grunt) {
 	 * @param {Object} options
 	 */
 	var run = function(files, options) {
+		// Normalize paths
+		options.srcPrefix = path.normalize(options.srcPrefix);
+		options.destPrefix = path.normalize(options.destPrefix);
+
 		verbose.writeln('Using srcPrefix: ' + options.srcPrefix);
 		verbose.writeln('Using destPrefix: ' + options.destPrefix);
 

--- a/test/bowercopy_test.js
+++ b/test/bowercopy_test.js
@@ -89,5 +89,19 @@ exports.bowercopy = {
 		test.ok(grunt.file.exists('tmp/js/plugins/jquery.minlight.js'), 'Minlight copied to plugins directory');
 
 		test.done();
+	},
+	main_with_complex_dest_prefix: function (test) {
+		test.expect(1);
+
+		test.ok(grunt.file.exists('tmp/js/main_with_complex_dest_prefix/angular/angular.js'), 'Angular copied to plugins directory');
+		
+		test.done();
+	},
+	main_with_no_dest: function (test) {
+		test.expect(1);
+
+		test.ok(grunt.file.exists('tmp/js/libs/angular/angular.js'), 'Angular copied to plugins directory');
+		
+		test.done();
 	}
 };


### PR DESCRIPTION
Fixes an issue with the rmain regex where it assumes that a colon will
never appear in a file path.

The new regex matches all characters in a path until :main is encountered
at the end.

Colons can appear in full file paths on Windows (e.g. C:\path\to\file) and
I believe are also allowed under Linux, OSX, etc.

All tests now passing on Windows.